### PR TITLE
Corrects effect of showing the button labels while selected on editing m...

### DIFF
--- a/TLSwipeForOptionsCell/TLSwipeForOptionsCell.m
+++ b/TLSwipeForOptionsCell/TLSwipeForOptionsCell.m
@@ -120,7 +120,11 @@ NSString *const TLSwipeForOptionsCellShouldHideMenuNotification = @"TLSwipeForOp
 - (void)setEditing:(BOOL)editing animated:(BOOL)animated {
 	[super setEditing:editing animated:animated];
 	self.scrollView.scrollEnabled = !self.editing;
-//	NSLog(@"%d", editing);
+    
+    // Corrects effect of showing the button labels while selected on editing mode (comment line, build, run, add new items to table, enter edit mode and select an entry)
+    self.scrollViewButtonView.hidden = editing;
+
+    //	NSLog(@"%d", editing);
 }
 
 - (UILabel *)textLabel {

--- a/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsCell.m
+++ b/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsCell.m
@@ -121,6 +121,9 @@ NSString *const TLSwipeForOptionsCellEnclosingTableViewDidBeginScrollingNotifica
     
     self.scrollView.scrollEnabled = !self.editing;
     
+    // Corrects effect of showing the button labels while selected on editing mode (comment line, build, run, add new items to table, enter edit mode and select an entry)
+    self.scrollViewButtonView.hidden = editing;
+    
     NSLog(@"%d", editing);
 }
 


### PR DESCRIPTION
![captura de ecra 2013-09-9 a s 09 22 18](https://f.cloud.github.com/assets/5132870/1106794/19eedf52-194f-11e3-9f71-cb6913f6c260.png)

Corrects effect of showing the button labels while selected on editing mode.

To reproduce comment line, build, run, add new items to table, enter edit mode and select an entry.

See attached image for depiction.
