### PR TITLE
Removed tableViewCell property from custom UIScrollView, now uses its superview

### DIFF
--- a/TLSwipeForOptionsCell/TLSwipeForOptionsCell.m
+++ b/TLSwipeForOptionsCell/TLSwipeForOptionsCell.m
@@ -47,7 +47,6 @@ NSString *const TLSwipeForOptionsCellShouldHideMenuNotification = @"TLSwipeForOp
 	self.isShowingMenu = NO;
 	
 	TLSwipeForOptionsScrollView *scrollView = [[TLSwipeForOptionsScrollView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds))];
-    scrollView.tableViewCell = self;
 	scrollView.contentSize = CGSizeMake(CGRectGetWidth(self.bounds) + kCatchWidth, CGRectGetHeight(self.bounds));
 	scrollView.delegate = self;
 	scrollView.showsHorizontalScrollIndicator = NO;

--- a/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsScrollView.h
+++ b/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsScrollView.h
@@ -10,6 +10,4 @@
 
 @interface TLSwipeForOptionsScrollView : UIScrollView
 
-@property (nonatomic, weak) UITableViewCell *tableViewCell;
-
 @end

--- a/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsScrollView.m
+++ b/UITableViewCell-Swipe-for-Options/TLSwipeForOptionsScrollView.m
@@ -12,20 +12,20 @@
 
 -(void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    [self.tableViewCell touchesBegan: touches withEvent: event];
+    [self.superview touchesBegan: touches withEvent: event];
 }
 
 -(void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
-    [self.tableViewCell touchesEnded:touches withEvent: event];
+    [self.superview touchesEnded:touches withEvent: event];
 }
 
 -(void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
-    [self.tableViewCell touchesMoved:touches withEvent:event];
+    [self.superview touchesMoved:touches withEvent:event];
 }
 
 -(void) touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
-    [self.tableViewCell touchesCancelled:touches withEvent:event];
+    [self.superview touchesCancelled:touches withEvent:event];
 }
 
 @end


### PR DESCRIPTION
Any subclass would override the content view, leaving the custom scroll view with a nil ptr.
I guess this is less flexible but we could even nest the custom scroll view inside the cell itself to make it opaque for the end user.
